### PR TITLE
Add make target to update Quay API spec from upstream

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,3 +18,22 @@ generate-quay-api:
     gofmt -w quay_api && \
     cd quay_api && \
     go mod tidy
+
+# Update Quay API spec from a Quay instance
+# This fetches the Swagger 2.0 spec from Quay and converts it to OpenAPI 3.0.1
+# Prerequisites: podman (or docker), curl, jq
+# Usage: make update-quay-api-spec QUAY_INSTANCE=https://quay.io
+QUAY_INSTANCE ?= https://quay.io
+.PHONY: update-quay-api-spec
+update-quay-api-spec:
+	@echo "Starting swagger-converter..."
+	podman run -d --rm -p 8080:8080 --name swagger-converter docker.io/swaggerapi/swagger-converter:v1.0.5
+	@sleep 2
+	@echo "Converting Quay API spec from Swagger 2.0 to OpenAPI 3.0.1..."
+	curl --silent --data "$$(curl --silent --location $(QUAY_INSTANCE)/api/v1/discovery)" \
+		-H "Content-Type: application/json" \
+		http://localhost:8080/api/convert | \
+		jq 'del(.. | .security?) | del(.components.securitySchemes)' \
+		> code_generator/quay_api.json
+	podman stop swagger-converter
+	@echo "Done! quay_api.json updated from $(QUAY_INSTANCE)."

--- a/README.md
+++ b/README.md
@@ -19,7 +19,30 @@ export QUAY_TOKEN=""
 make testacc
 ```
 
-### Generate Quay API
+### Update Quay API Spec
+The Go API client is generated from an OpenAPI 3.0.1 specification stored in `code_generator/quay_api.json`. Quay instances expose their API spec in Swagger 2.0 format at `/api/v1/discovery`, so updating the spec requires fetching and converting it.
+
+**Prerequisites:** podman (or docker), curl, jq
+
+To update the API spec from quay.io:
+```bash
+make update-quay-api-spec
+```
+
+To update from a different Quay instance:
+```bash
+make update-quay-api-spec QUAY_INSTANCE=https://quay.example.com
+```
+
+This target:
+1. Starts a swagger-converter container
+2. Fetches the Swagger 2.0 spec from the Quay instance
+3. Converts it to OpenAPI 3.0.1
+4. Removes OAuth2 security definitions (not used by this provider)
+5. Saves the result to `code_generator/quay_api.json`
+
+### Generate Quay API Client
+After updating the API spec, regenerate the Go client:
 ```bash
 make generate-quay-api
 ```


### PR DESCRIPTION
## Summary
- Add `update-quay-api-spec` Makefile target that automates fetching and converting the Quay API specification
- Target fetches Swagger 2.0 spec from a Quay instance, converts to OpenAPI 3.0.1, and removes unused OAuth2 security definitions
- Add documentation to README explaining the process and prerequisites

Closes #43

## Test plan
- [ ] Run `make -n update-quay-api-spec` to verify the target syntax
- [ ] Run `make update-quay-api-spec` to test the full process (requires podman/docker)
- [ ] Verify generated spec matches expected format
- [ ] Run `make generate-quay-api` and `go build .` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)